### PR TITLE
python-orjson: update to 3.9.7

### DIFF
--- a/abi_used_symbols
+++ b/abi_used_symbols
@@ -67,12 +67,13 @@ libc.so.6:free
 libc.so.6:fstat64
 libc.so.6:getcwd
 libc.so.6:getenv
+libc.so.6:lseek64
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
-libc.so.6:mmap
+libc.so.6:mmap64
 libc.so.6:munmap
 libc.so.6:open64
 libc.so.6:posix_memalign
@@ -80,6 +81,7 @@ libc.so.6:pthread_getspecific
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
 libc.so.6:pthread_setspecific
+libc.so.6:read
 libc.so.6:readlink
 libc.so.6:realloc
 libc.so.6:realpath

--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.9.2
-release    : 29
+version    : 3.9.7
+release    : 30
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.9.2.tar.gz : 24257c8f641979bf25ecd3e27251b5cc194cdd3a6e96004aac8446f5e63d9664
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.9.7.tar.gz : 85e39198f78e2f7e054d296395f6c96f5e02892337746ef5b6a1bf3ed5910142
 license    :
     - Apache-2.0
     - MIT

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.2.dist-info/license_files/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.2.dist-info/license_files/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/license_files/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/license_files/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2023-07-12</Date>
-            <Version>3.9.2</Version>
+        <Update release="30">
+            <Date>2023-09-17</Date>
+            <Version>3.9.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Changes:**
- Fix compatibility with CPython 3.12
- Fix hash builder using default values
- Remove futex from module import and initialization path
- Fix numpy reference leak on unsupported array dtype
- Fix numpy.datetime64 reference handling
- Minor performance improvements
- Handle some FFI removals in CPython 3.13

**Test Plan:**
- Ran through all examples in GitHub "Usage" section

### Checklist

- [x] Package was built and tested against unstable
